### PR TITLE
feat: add last-run flag to cloud-build

### DIFF
--- a/docs/services/cloudbuild/cloudbuild.md
+++ b/docs/services/cloudbuild/cloudbuild.md
@@ -58,7 +58,7 @@ gtail can get historic logs for a Cloud Build that has already completed
 gtail cloud-build historic -h
 ```
 ```text
-Get the cloud build logs for a trigger that has already completed
+Get the Cloud Build logs for a trigger that has already completed
 
 Usage:
   gtail cloud-build historic [flags]
@@ -66,12 +66,13 @@ Usage:
 Flags:
   -h, --help            help for historic
       --hours-ago int   Roughly how many hours ago the build happened. Searches a window of time from then till now (default 24)
+      --last-run        Get the logs for the last run of the trigger
 
 Global Flags:
       --build-id string       The cloud build ID
   -d, --debug                 Enable debug logging
   -o, --output string         The output format either json or a template string
-  -p, --project string        The GCP project ID
+  -p, --project string        The GCP project ID (default "gs-app-iac")
   -r, --region string         The GCP region (default "us-central1")
       --severity strings      The severity of logs to include
       --trigger-name string   The name of the cloud build trigger to use
@@ -80,3 +81,5 @@ Global Flags:
 The `--hours-ago` flag will search for a build that started within the last `n` hours. If you don't specify this flag it will search for a build that started within the last 24 hours.
 
 | Note: starting a historic build with the `--trigger-name` flag will tail all builds for that trigger in the given time period.
+
+The `--last-run` flag will get the logs for the last run of the trigger, it needs to be used with the `--trigger-name` flag. The time it ran will be pulled from the build details so `--hours-ago` will be ignored.

--- a/internal/app/gtail/cmd/cloudbuild.go
+++ b/internal/app/gtail/cmd/cloudbuild.go
@@ -38,6 +38,7 @@ var historicCloudBuildCmd = &cobra.Command{
 		lf := logfilter.New(projectID, logfilter.CloudBuildLogFilterType).
 			WithBuildTriggerName(buildTriggerName).
 			WithID(logID).
+			WithLastRun(lastRun).
 			WithHoursAgo(hoursAgo)
 		return la.GetHistoricalLogEntries(lf)
 	},
@@ -52,6 +53,7 @@ func getCloudBuildCommand() *cobra.Command {
 	cloudBuild.PersistentFlags().StringVar(&logID, "build-id", logID, "The cloud build ID")
 	cloudBuild.PersistentFlags().StringSliceVar(&severities, "severity", severities, "The severity of logs to include")
 	cloudBuild.PersistentFlags().StringVarP(&outputFormat, "output", "o", outputFormat, "The output format either json or a template string")
+	historicCloudBuildCmd.Flags().BoolVar(&lastRun, "last-run", lastRun, "Get the logs for the last run of the trigger")
 	historicCloudBuildCmd.Flags().IntVar(&hoursAgo, "hours-ago", hoursAgo, "Roughly how many hours ago the build happened. Searches a window of time from then till now")
 
 	return cloudBuild

--- a/internal/app/gtail/cmd/flags.go
+++ b/internal/app/gtail/cmd/flags.go
@@ -5,19 +5,20 @@ import (
 )
 
 var (
+	debug            bool
+	lastRun          bool
+	hoursAgo         int    = 24
 	projectID        string = os.Getenv("GCP_PROJECT_ID")
 	region           string = os.Getenv("GCP_REGION")
 	logID            string
-	severities       []string
 	outputFormat     string
-	debug            bool
-	hoursAgo         int = 24
 	buildTriggerName string
 	functionName     string
 	serviceName      string
 	clusterName      string
 	tailDuration     string = "10m"
 	tailTopic        string
+	severities       []string
 )
 
 func init() {

--- a/internal/pkg/logfilter/cloudbuild.go
+++ b/internal/pkg/logfilter/cloudbuild.go
@@ -3,6 +3,7 @@ package logfilter
 import (
 	"context"
 	"fmt"
+	"time"
 
 	cloudbuild "cloud.google.com/go/cloudbuild/apiv1/v2"
 	"cloud.google.com/go/cloudbuild/apiv1/v2/cloudbuildpb"
@@ -25,4 +26,28 @@ func resolveBuildTriggerID(projectID, triggerName string) (string, error) {
 	}
 	logger.Debug("Resolved trigger ID for %s: %s", trigger, trigger.Id)
 	return trigger.Id, nil
+}
+
+func getLatestBuildID(projectID, triggerID string) (string, *time.Time, error) {
+	client, err := cloudbuild.NewClient(context.Background())
+	if err != nil {
+		return "", nil, fmt.Errorf("NewClient error: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	logger.Debug("Getting latest build for trigger %s", triggerID)
+	builds := client.ListBuilds(context.Background(), &cloudbuildpb.ListBuildsRequest{
+		ProjectId: projectID,
+		Filter:    fmt.Sprintf("trigger_id=%s", triggerID),
+		PageSize:  1,
+	})
+
+	build, err := builds.Next()
+	if err != nil {
+		return "", nil, fmt.Errorf("ListBuilds error: %v", err)
+	}
+	createTime := build.GetCreateTime().AsTime()
+
+	return build.Id, &createTime, nil
+
 }


### PR DESCRIPTION
use the flag when you know the trigger name and just want the historical logs for the most recent build for that trigger
